### PR TITLE
deviseのログインをCookieで保持

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :posts
+  
+  def remember_me
+    true
+  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -164,13 +164,13 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 2.weeks
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true
 
   # If true, extends the user's remember period when remembered via cookie.
-  # config.extend_remember_period = false
+  config.extend_remember_period = true
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.


### PR DESCRIPTION
## 対象のissue
#3 

## やったこと
deviseのログインをCookieで保持するようにした。

## 動作確認
- [x] Chromeのデベロッパーツールで以下のようにCookieがセットされているか
<img width="434" alt="スクリーンショット 2022-03-15 3 59 23" src="https://user-images.githubusercontent.com/8194473/158242234-a5ad9c6b-19f0-4fbf-92bd-27cebbe1a591.png">

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）