### PR TITLE
Modify forget_password_page

### DIFF
--- a/app/assets/stylesheets/devise.scss
+++ b/app/assets/stylesheets/devise.scss
@@ -121,3 +121,12 @@
 
     }
 }
+
+#error_explanation {
+    color: red;
+    border: 1px solid;
+    padding: 10px;
+    border-radius: 5px;
+    margin-bottom: 10px;
+    margin-top: 10px;
+}

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,23 @@
-<h2>Forgot your password?</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="signup">
+  <div class="title">
+    <h2>パスワードをお忘れですか？</h2>
   </div>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <div class="signup_content">
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
+      <div class="field">
+        <%= f.label :email, "メールアドレス", class: "label-name" %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "dynamic-line" %>
+        <div class="underline-center"></div>
+      </div>
 
-<%= render "devise/shared/links" %>
+      <div class="actions">
+        <%= f.submit "パスワードをリセットする", class: "actions-btn"%>
+      </div>
+      <div class="another-pages">
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,11 +1,11 @@
 <% if resource.errors.any? %>
   <div id="error_explanation">
-    <h2>
+    <p>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
-    </h2>
+    </p>
     <ul>
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>


### PR DESCRIPTION
## 対象のissue
#12

## 変更内容
* パスワードを忘れた人へのページのデザインを編集
* エラーメッセージのデザインを編集
* signup.cssという名前のファイルをdevise.cssに変更

## 影響範囲
`app/assets/stylesheets/devise.scss`
`app/views/devise/passwords/new.html.erb`
`app/views/devise/shared/_error_messages.html.erb`
